### PR TITLE
avicii: Increase number of alarm volume steps

### DIFF
--- a/product.prop
+++ b/product.prop
@@ -1,3 +1,4 @@
 # Audio
+ro.config.alarm_vol_steps=25
 ro.config.media_vol_steps=25
 ro.config.vc_call_vol_steps=7


### PR DESCRIPTION
Hi all

This should increase the number of steps that are available for setting the alarm volume.
The reason behind this is that avicii is **very** loud even on the lowest setting available for alarms.

Note: I wasn't able to test this due to missing experience with building lineage for myself.